### PR TITLE
add dplyr to libraries loaded

### DIFF
--- a/server.R
+++ b/server.R
@@ -1,3 +1,4 @@
+library(dplyr)
 library(projmanr)
 
 shinyServer(function(input, output) {


### PR DESCRIPTION
this fixes the R runtime complaining that it can't find the `%>%` function.